### PR TITLE
Add support for `customExecuteFn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ The `graphqlHTTP` function accepts the following options:
 
   * **`fieldResolver`**
 
+  * **`customExecuteFn`**: An optional function which will be used to execute
+    instead of default `execute` from `graphql-js`.
 
 ## HTTP Usage
 


### PR DESCRIPTION
Hello! I'm using `koa-graphql` for almost a year now without any issues so far.
Recently I heard about [graphql-jit](https://github.com/zalando-incubator/graphql-jit) and I want to experiment with it in my GraphQL server, but unfortunately `koa-graphql` doesn't support the `customExecuteFn` option which is needed to integrate `graphql-jit`.

As this project is a port of `express-graphql` which has the support for `customExecuteFn`, I made the required changes [based on the implementation in express-graphql](https://github.com/graphql/express-graphql/search?q=customExecuteFn).

Let me know if there is anything needs to be changed!