### PR TITLE
Add support for customParseFn option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ The `graphqlHTTP` function accepts the following options:
   errors produced by fulfilling a GraphQL operation. If no function is
   provided, GraphQL's default spec-compliant [`formatError`][] function will be used.
 
+- **`customParseFn`**: An optional function which will be used to create a document
+  instead of the default `parse` from `graphql-js`.
+
 - **`formatError`**: is deprecated and replaced by `customFormatErrorFn`. It will be
   removed in version 1.0.0.
 

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -13,7 +13,7 @@ import request from 'supertest';
 import Koa from 'koa';
 import mount from 'koa-mount';
 import session from 'koa-session';
-import parse from 'co-body';
+import parseBody from 'co-body';
 import getRawBody from 'raw-body';
 
 import {
@@ -23,8 +23,10 @@ import {
   GraphQLString,
   GraphQLError,
   BREAK,
+  Source,
   validate,
   execute,
+  parse,
 } from 'graphql';
 import graphqlHTTP from '../';
 
@@ -903,7 +905,7 @@ describe('GraphQL-HTTP tests', () => {
       const app = server();
       app.use(async function (ctx, next) {
         if (ctx.is('application/graphql')) {
-          ctx.request.body = await parse.text(ctx);
+          ctx.request.body = await parseBody.text(ctx);
         }
         await next();
       });
@@ -927,7 +929,7 @@ describe('GraphQL-HTTP tests', () => {
       const app = server();
       app.use(async function (ctx, next) {
         if (ctx.is('*/*')) {
-          ctx.request.body = await parse.text(ctx);
+          ctx.request.body = await parseBody.text(ctx);
         }
         await next();
       });
@@ -2021,6 +2023,121 @@ describe('GraphQL-HTTP tests', () => {
     });
   });
 
+  describe('Custom execute', () => {
+    it('allow to replace default execute', async () => {
+      const app = server();
+
+      let seenExecuteArgs;
+
+      app.use(
+        mount(
+          urlString(),
+          graphqlHTTP(() => ({
+            schema: TestSchema,
+            async customExecuteFn(...args) {
+              seenExecuteArgs = args;
+              const result = await Promise.resolve(execute(...args));
+              result.data.test2 = 'Modification';
+              return result;
+            },
+          })),
+        ),
+      );
+
+      const response = await request(app.listen())
+        .get(urlString({ query: '{test}', raw: '' }))
+        .set('Accept', 'text/html');
+
+      expect(response.text).to.equal(
+        '{"data":{"test":"Hello World","test2":"Modification"}}',
+      );
+      expect(seenExecuteArgs).to.not.equal(null);
+    });
+
+    it('catches errors thrown from custom execute function', async () => {
+      const app = server();
+
+      app.use(
+        mount(
+          urlString(),
+          graphqlHTTP(() => ({
+            schema: TestSchema,
+            customExecuteFn() {
+              throw new Error('I did something wrong');
+            },
+          })),
+        ),
+      );
+
+      const response = await request(app.listen())
+        .get(urlString({ query: '{test}', raw: '' }))
+        .set('Accept', 'text/html');
+
+      expect(response.status).to.equal(400);
+      expect(response.text).to.equal(
+        '{"errors":[{"message":"I did something wrong"}]}',
+      );
+    });
+  });
+
+  describe('Custom parse function', () => {
+    it('can replace default parse functionality', async () => {
+      const app = server();
+
+      let seenParseArgs;
+
+      app.use(
+        mount(
+          urlString(),
+          graphqlHTTP(() => {
+            return {
+              schema: TestSchema,
+              customParseFn(args) {
+                seenParseArgs = args;
+                return parse(new Source('{test}', 'Custom parse function'));
+              },
+            };
+          }),
+        ),
+      );
+
+      const response = await request(app.listen()).get(
+        urlString({ query: '----' }),
+      );
+
+      expect(response.status).to.equal(200);
+      expect(response.text).to.equal('{"data":{"test":"Hello World"}}');
+      expect(seenParseArgs).property('body', '----');
+    });
+
+    it('can throw errors', async () => {
+      const app = server();
+
+      app.use(
+        mount(
+          urlString(),
+          graphqlHTTP(() => {
+            return {
+              schema: TestSchema,
+              customParseFn() {
+                throw new GraphQLError('my custom parse error');
+              },
+            };
+          }),
+        ),
+      );
+
+      const response = await request(app.listen()).get(
+        urlString({ query: '----' }),
+      );
+
+      expect(response.status).to.equal(400);
+      expect(response.text).to.equal(
+        '{"errors":[{"message":"my custom parse error"}]}',
+      );
+    });
+  });
+
   describe('Custom result extensions', () => {
     it('allows for adding extensions', async () => {
       const app = server();
@@ -2120,63 +2237,6 @@ describe('GraphQL-HTTP tests', () => {
       expect(response.type).to.equal('application/json');
       expect(response.text).to.equal(
         '{"data":{"test":"Hello World"},"extensions":{"eventually":42}}',
-      );
-    });
-  });
-
-  describe('Custom execute', () => {
-    it('allow to replace default execute', async () => {
-      const app = server();
-
-      let seenExecuteArgs;
-
-      app.use(
-        mount(
-          urlString(),
-          graphqlHTTP(() => ({
-            schema: TestSchema,
-            async customExecuteFn(...args) {
-              seenExecuteArgs = args;
-              const result = await Promise.resolve(execute(...args));
-              result.data.test2 = 'Modification';
-              return result;
-            },
-          })),
-        ),
-      );
-
-      const response = await request(app.listen())
-        .get(urlString({ query: '{test}', raw: '' }))
-        .set('Accept', 'text/html');
-
-      expect(response.text).to.equal(
-        '{"data":{"test":"Hello World","test2":"Modification"}}',
-      );
-      expect(seenExecuteArgs).to.not.equal(null);
-    });
-
-    it('catches errors thrown from custom execute function', async () => {
-      const app = server();
-
-      app.use(
-        mount(
-          urlString(),
-          graphqlHTTP(() => ({
-            schema: TestSchema,
-            customExecuteFn() {
-              throw new Error('I did something wrong');
-            },
-          })),
-        ),
-      );
-
-      const response = await request(app.listen())
-        .get(urlString({ query: '{test}', raw: '' }))
-        .set('Accept', 'text/html');
-
-      expect(response.status).to.equal(400);
-      expect(response.text).to.equal(
-        '{"errors":[{"message":"I did something wrong"}]}',
       );
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,12 @@ export type OptionsData = {
   customFormatErrorFn?: ?(error: GraphQLError, context?: ?any) => mixed,
 
   /**
+   * An optional function which will be used to create a document instead of
+   * the default `parse` from `graphql-js`.
+   */
+  customParseFn?: ?(source: Source) => DocumentNode,
+
+  /**
    * `formatError` is deprecated and replaced by `customFormatErrorFn`. It will
    *  be removed in version 1.0.0.
    */
@@ -152,6 +158,7 @@ function graphqlHTTP(options: Options): Middleware {
     let formatErrorFn = formatError;
     let validateFn = validate;
     let executeFn = execute;
+    let parseFn = parse;
     let extensionsFn;
     let showGraphiQL;
     let query;
@@ -202,6 +209,7 @@ function graphqlHTTP(options: Options): Middleware {
 
       validateFn = optionsData.customValidateFn || validateFn;
       executeFn = optionsData.customExecuteFn || executeFn;
+      parseFn = optionsData.customParseFn || parseFn;
       formatErrorFn =
         optionsData.customFormatErrorFn ||
         optionsData.formatError ||
@@ -253,7 +261,7 @@ function graphqlHTTP(options: Options): Middleware {
 
         // Parse source to AST, reporting any syntax error.
         try {
-          documentAST = parse(source);
+          documentAST = parseFn(source);
         } catch (syntaxError) {
           // Return 400: Bad Request if any syntax errors errors exist.
           response.status = 400;


### PR DESCRIPTION
* Add support for customParseFn option
* Update README.md
* Make customParseFn have the same signature as parse()

Ref commit: https://github.com/graphql/express-graphql/commit/604f8e6e99e811b983186f977d2d184bb322b700
