### PR TITLE
Update express-graphql

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "express-graphql": "0.9.0",
+        "express-graphql": "0.12.0",
         "http-errors": "^1.7.3"
       },
       "devDependencies": {
@@ -5699,20 +5699,20 @@
       }
     },
     "node_modules/express-graphql": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.9.0.tgz",
-      "integrity": "sha512-wccd9Lb6oeJ8yHpUs/8LcnGjFUUQYmOG9A5BNLybRdCzGw0PeUrtBxsIR8bfiur6uSW4OvPkVDoYH06z6/N9+w==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.12.0.tgz",
+      "integrity": "sha512-DwYaJQy0amdy3pgNtiTDuGGM2BLdj+YO2SgbKoLliCfuHv3VVTt7vNG/ZqK2hRYjtYHE2t2KB705EU94mE64zg==",
       "dependencies": {
         "accepts": "^1.3.7",
         "content-type": "^1.0.4",
-        "http-errors": "^1.7.3",
+        "http-errors": "1.8.0",
         "raw-body": "^2.4.1"
       },
       "engines": {
-        "node": ">= 8.x"
+        "node": ">= 10.x"
       },
       "peerDependencies": {
-        "graphql": "^14.4.1"
+        "graphql": "^14.7.0 || ^15.3.0"
       }
     },
     "node_modules/extend": {
@@ -15936,13 +15936,13 @@
       "dev": true
     },
     "express-graphql": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.9.0.tgz",
-      "integrity": "sha512-wccd9Lb6oeJ8yHpUs/8LcnGjFUUQYmOG9A5BNLybRdCzGw0PeUrtBxsIR8bfiur6uSW4OvPkVDoYH06z6/N9+w==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.12.0.tgz",
+      "integrity": "sha512-DwYaJQy0amdy3pgNtiTDuGGM2BLdj+YO2SgbKoLliCfuHv3VVTt7vNG/ZqK2hRYjtYHE2t2KB705EU94mE64zg==",
       "requires": {
         "accepts": "^1.3.7",
         "content-type": "^1.0.4",
-        "http-errors": "^1.7.3",
+        "http-errors": "1.8.0",
         "raw-body": "^2.4.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "start": "node -r babel-register examples/index.js"
   },
   "dependencies": {
-    "express-graphql": "0.9.0",
+    "express-graphql": "0.12.0",
     "http-errors": "^1.7.3"
   },
   "devDependencies": {

--- a/src/__tests__/http-test.ts
+++ b/src/__tests__/http-test.ts
@@ -1538,7 +1538,7 @@ describe('GraphQL-HTTP tests', () => {
         .set('Content-Type', 'application/json')
         .send(`{ "query": "{ ${new Array(102400).fill('test').join('')} }" }`);
 
-      expect(response.status).to.equal(400);
+      expect(response.status).to.equal(413);
       expect(JSON.parse(response.text)).to.deep.equal({
         errors: [{ message: 'Invalid body: request entity too large.' }],
       });

--- a/src/index.js
+++ b/src/index.js
@@ -22,14 +22,12 @@ import {
   getOperationAST,
   specifiedRules,
 } from 'graphql';
-import expressGraphQL from 'express-graphql';
+import { getGraphQLParams } from 'express-graphql';
 
 import type { Context, Request, Response } from 'koa';
 
 import { renderGraphiQL } from './renderGraphiQL';
 import type { GraphiQLOptions } from './renderGraphiQL';
-
-const { getGraphQLParams } = expressGraphQL;
 
 /**
  * Used to configure the graphqlHTTP middleware by providing a schema


### PR DESCRIPTION
Update to latest (`0.12.0`) version of express-graphql. This is to have npm resolve to `graphql@15.3.0`.